### PR TITLE
Run Playwright tests in parallel

### DIFF
--- a/playwright.config.cjs
+++ b/playwright.config.cjs
@@ -4,10 +4,10 @@ const { defineConfig } = require('@playwright/test');
 module.exports = defineConfig({
   testDir: './test/browser',
   testMatch: '**/*.spec.cjs',
-  fullyParallel: false,
+  fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: 1,
+  workers: process.env.CI ? 2 : undefined,
   reporter: 'list',
 
   use: {


### PR DESCRIPTION
The browser suite ran 17 tests on a single worker (~45s in CI), with several tests dominated by fixed waits for quicklink's idle-callback prefetch window. The specs are isolated (per-test contexts, no shared hooks or server state), so enable fullyParallel.

Use 2 workers in CI (4-core runners, chromium contention) and Playwright's adaptive default locally.