### PR TITLE
Restore the canonical image from cache in each job

### DIFF
--- a/.github/actions/canonical-image/action.yml
+++ b/.github/actions/canonical-image/action.yml
@@ -1,0 +1,48 @@
+name: Canonical image
+description: Restore the canonical devcontainer image from the cache, building and caching it on a miss
+
+inputs:
+  ruby-version:
+    description: Ruby version baked into the image
+    required: true
+  image:
+    description: Docker image tag for the canonical container
+    required: false
+    default: speedshop-devcontainer
+  platform:
+    description: Docker platform for the canonical container
+    required: false
+    default: linux/amd64
+
+runs:
+  using: composite
+  steps:
+  - name: Ensure image cache directory exists
+    shell: bash
+    run: mkdir -p .cache/canonical-image
+  # The tarball is stored uncompressed; actions/cache zstd-compresses it on
+  # save and restore, so gzipping here would only slow down `docker load`.
+  - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+    with:
+      path: .cache/canonical-image/${{ inputs.image }}.tar
+      key: ${{ runner.os }}-canonical-image-v2-${{ hashFiles('.devcontainer/Dockerfile') }}-ruby-${{ inputs.ruby-version }}
+  - name: Load or build canonical image
+    shell: bash
+    env:
+      CANONICAL_IMAGE: ${{ inputs.image }}
+      CANONICAL_PLATFORM: ${{ inputs.platform }}
+      CANONICAL_RUBY_VERSION: ${{ inputs.ruby-version }}
+    run: |
+      tarball=".cache/canonical-image/${CANONICAL_IMAGE}.tar"
+      if [ -f "$tarball" ]; then
+        docker load < "$tarball"
+      else
+        docker build \
+          --platform "$CANONICAL_PLATFORM" \
+          --target ci \
+          --build-arg "RUBY_VERSION=$CANONICAL_RUBY_VERSION" \
+          -f .devcontainer/Dockerfile \
+          -t "$CANONICAL_IMAGE" \
+          .
+        docker save "$CANONICAL_IMAGE" > "$tarball"
+      fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,49 +12,19 @@ env:
   CANONICAL_ENV_HOME: ${{ github.workspace }}/.cache/canonical-home
 
 jobs:
-  prepare:
-    runs-on: ubuntu-24.04
-    steps:
-    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      with:
-        persist-credentials: false
-    - name: Ensure image cache directory exists
-      run: mkdir -p .cache/canonical-image
-    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-      id: canonical_image_cache
-      with:
-        path: .cache/canonical-image/${{ env.DEVCONTAINER_IMAGE }}.tar.gz
-        key: ${{ runner.os }}-canonical-image-v1-${{ hashFiles('mise.toml', 'mise.lock', '.devcontainer/Dockerfile') }}
-    - name: Build and archive canonical container
-      if: steps.canonical_image_cache.outputs.cache-hit != 'true'
-      run: |
-        docker build \
-          --platform "$DEVCONTAINER_PLATFORM" \
-          --target ci \
-          --build-arg "RUBY_VERSION=$(awk -F'"' '/^ruby = / { print $2; exit }' mise.toml)" \
-          -f .devcontainer/Dockerfile \
-          -t "$DEVCONTAINER_IMAGE" \
-          .
-        docker save "$DEVCONTAINER_IMAGE" | gzip > ".cache/canonical-image/${DEVCONTAINER_IMAGE}.tar.gz"
-    - uses: actions/upload-artifact@v4
-      with:
-        name: canonical-image
-        path: .cache/canonical-image/${{ env.DEVCONTAINER_IMAGE }}.tar.gz
-        if-no-files-found: error
-
   lint:
-    needs: prepare
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       with:
         persist-credentials: false
-    - uses: actions/download-artifact@v4
+    - name: Determine Ruby version
+      id: ruby
+      run: |
+        echo "version=$(awk -F'"' '/^ruby = / { print $2; exit }' mise.toml)" >> "$GITHUB_OUTPUT"
+    - uses: ./.github/actions/canonical-image
       with:
-        name: canonical-image
-        path: .cache/canonical-image
-    - name: Load canonical container
-      run: gunzip -c ".cache/canonical-image/${DEVCONTAINER_IMAGE}.tar.gz" | docker load
+        ruby-version: ${{ steps.ruby.outputs.version }}
     - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: .cache/canonical-home
@@ -78,18 +48,18 @@ jobs:
         '
 
   build:
-    needs: prepare
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       with:
         persist-credentials: false
-    - uses: actions/download-artifact@v4
+    - name: Determine Ruby version
+      id: ruby
+      run: |
+        echo "version=$(awk -F'"' '/^ruby = / { print $2; exit }' mise.toml)" >> "$GITHUB_OUTPUT"
+    - uses: ./.github/actions/canonical-image
       with:
-        name: canonical-image
-        path: .cache/canonical-image
-    - name: Load canonical container
-      run: gunzip -c ".cache/canonical-image/${DEVCONTAINER_IMAGE}.tar.gz" | docker load
+        ruby-version: ${{ steps.ruby.outputs.version }}
     - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: .cache/canonical-home
@@ -115,18 +85,18 @@ jobs:
         '
 
   test:
-    needs: prepare
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       with:
         persist-credentials: false
-    - uses: actions/download-artifact@v4
+    - name: Determine Ruby version
+      id: ruby
+      run: |
+        echo "version=$(awk -F'"' '/^ruby = / { print $2; exit }' mise.toml)" >> "$GITHUB_OUTPUT"
+    - uses: ./.github/actions/canonical-image
       with:
-        name: canonical-image
-        path: .cache/canonical-image
-    - name: Load canonical container
-      run: gunzip -c ".cache/canonical-image/${DEVCONTAINER_IMAGE}.tar.gz" | docker load
+        ruby-version: ${{ steps.ruby.outputs.version }}
     - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: .cache/canonical-home

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,9 @@ jobs:
         echo "Using Ruby $ruby_version from $ruby_source"
         echo "value=$ruby_version" >> "$GITHUB_OUTPUT"
         echo "source=$ruby_source" >> "$GITHUB_OUTPUT"
+    - uses: ./.github/actions/canonical-image
+      with:
+        ruby-version: ${{ steps.deploy_ruby.outputs.value }}
     - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: .cache/canonical-home

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -28,6 +28,13 @@ jobs:
     - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       with:
         persist-credentials: false
+    - name: Determine Ruby version
+      id: ruby
+      run: |
+        echo "version=$(awk -F'"' '/^ruby = / { print $2; exit }' mise.toml)" >> "$GITHUB_OUTPUT"
+    - uses: ./.github/actions/canonical-image
+      with:
+        ruby-version: ${{ steps.ruby.outputs.version }}
     - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: .cache/canonical-home


### PR DESCRIPTION
Replace the prepare job and its save/gzip/upload-artifact/download/ gunzip/load round trip with a composite action each job uses directly: restore the image tarball from actions/cache, docker load on a hit, docker build + save on a miss (the cache post-step uploads it).

- The tarball is cached uncompressed; actions/cache already zstd-compresses on save/restore, which decompresses several times faster than the gzip pipe it replaces.
- The cache key now hashes only the Dockerfile plus the Ruby version the image bakes in, instead of all of mise.toml/mise.lock - bumping node, terraform, or other runtime tools no longer forces a ~3 minute image rebuild.
- Deploy and Integration Tests previously built the image from scratch inside canonical-env.sh on every run with no cache at all; they now use the same composite action.

On a cache miss the Build jobs each build the image in parallel (duplicate compute, rare event) and the first finisher wins the cache save; wall-clock is still faster than the old serial prepare job.