### PR TITLE
Do not fail current day on SLA status

### DIFF
--- a/_plugins/generate_data.rb
+++ b/_plugins/generate_data.rb
@@ -1,3 +1,4 @@
+require "date"
 require "fileutils"
 require "json"
 
@@ -57,10 +58,16 @@ module Speedshop
 
   module SlaStatusData
     CUTOFF_DATE = "2026-01-01"
+    PASS_FAIL_STATUSES = %w[green red].freeze
+    PERFORMANCE_WINDOWS = {
+      "last_30_days" => ->(today) { today - 30 },
+      "last_90_days" => ->(today) { today - 90 },
+      "last_6_months" => ->(today) { today << 6 }
+    }.freeze
 
     module_function
 
-    def normalize_file!(path, cutoff_date: CUTOFF_DATE)
+    def normalize_file!(path, cutoff_date: CUTOFF_DATE, today: current_japan_date)
       return unless File.exist?(path)
 
       payload = JSON.parse(File.read(path))
@@ -75,7 +82,49 @@ module Speedshop
       end
       payload["reply_histogram"] ||= Speedshop::GenerateDataDefaults.sla_status.fetch("reply_histogram")
 
+      recalculate_performance!(payload, today) if suppress_current_business_status!(payload, today)
+
       File.write(path, "#{JSON.pretty_generate(payload)}\n")
+    end
+
+    def current_japan_date
+      Time.now.getlocal("+09:00").to_date
+    end
+
+    def suppress_current_business_status!(payload, today)
+      status = payload.fetch("days", {})[today.to_s]
+      return false unless PASS_FAIL_STATUSES.include?(status)
+
+      payload["days"][today.to_s] = "future"
+      true
+    end
+
+    def recalculate_performance!(payload, today)
+      return unless payload["performance"].is_a?(Hash)
+
+      PERFORMANCE_WINDOWS.each do |key, start_date_for|
+        next unless payload["performance"].key?(key)
+
+        statuses = statuses_between(payload.fetch("days", {}), start_date_for.call(today), today)
+        payload["performance"][key] = performance_percentage(statuses)
+      end
+    end
+
+    def statuses_between(days, start_date, end_date)
+      days.filter_map do |date, status|
+        status if PASS_FAIL_STATUSES.include?(status) && date_in_range?(date, start_date, end_date)
+      end
+    end
+
+    def date_in_range?(date, start_date, end_date)
+      date = Date.parse(date)
+      date >= start_date && date < end_date
+    end
+
+    def performance_percentage(statuses)
+      return 0 if statuses.empty?
+
+      (statuses.count("green") * 100.0 / statuses.length).round(1)
     end
 
     def merge_reply_histogram!(path, stats)

--- a/test/ruby/sla_status_data_test.rb
+++ b/test/ruby/sla_status_data_test.rb
@@ -1,0 +1,58 @@
+require "minitest/autorun"
+require "tmpdir"
+require "jekyll"
+
+require_relative "../../_plugins/generate_data"
+
+class SlaStatusDataTest < Minitest::Test
+  def test_normalize_file_never_marks_current_day_red
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "sla_status.json")
+      File.write(path, JSON.pretty_generate(status_payload(
+        "2026-06-25" => "green",
+        "2026-06-26" => "red",
+        "2026-06-29" => "red",
+        "2026-06-30" => "future"
+      )))
+
+      Speedshop::SlaStatusData.normalize_file!(path, today: Date.new(2026, 6, 29))
+
+      payload = JSON.parse(File.read(path))
+      assert_equal "future", payload.fetch("days").fetch("2026-06-29")
+      assert_equal 50.0, payload.fetch("performance").fetch("last_30_days")
+    end
+  end
+
+  def test_normalize_file_excludes_current_day_from_passing_status_too
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "sla_status.json")
+      File.write(path, JSON.pretty_generate(status_payload(
+        "2026-06-25" => "green",
+        "2026-06-26" => "red",
+        "2026-06-29" => "green"
+      )))
+
+      Speedshop::SlaStatusData.normalize_file!(path, today: Date.new(2026, 6, 29))
+
+      payload = JSON.parse(File.read(path))
+      assert_equal "future", payload.fetch("days").fetch("2026-06-29")
+      assert_equal 50.0, payload.fetch("performance").fetch("last_30_days")
+    end
+  end
+
+  def status_payload(days)
+    {
+      "sla_policy" => "Respond within 2 business days",
+      "generated_at" => "2026-06-29T00:00:00Z",
+      "start_date" => "2026-01-01",
+      "end_date" => "2026-12-31",
+      "holidays" => [],
+      "days" => days,
+      "performance" => {
+        "last_30_days" => 0,
+        "last_90_days" => 0,
+        "last_6_months" => 0
+      }
+    }
+  end
+end


### PR DESCRIPTION
## Summary
- Mark the current Japan date as future/pending if generated SLA data marks it green or red
- Recalculate SLA performance windows after suppressing the current day
- Add coverage for current-day red and green statuses

## Test plan
- bundle exec standardrb _plugins/generate_data.rb test/ruby/sla_status_data_test.rb
- mise run test:ruby
- pre-commit: mise run lint, mise run test:quick

## Demo
- Launched local dev stack and opened https://localhost:4000/status.html
- Verified 2026-06-29 renders as future